### PR TITLE
Remove unused local const values

### DIFF
--- a/cgi-fcgi/cgi-fcgi.c
+++ b/cgi-fcgi/cgi-fcgi.c
@@ -10,9 +10,6 @@
  * of this file, and for a DISCLAIMER OF ALL WARRANTIES.
  *
  */
-#ifndef lint
-static const char rcsid[] = "$Id: cgi-fcgi.c,v 1.20 2009/10/06 01:31:59 robs Exp $";
-#endif /* not lint */
 
 #include <assert.h>
 #include <ctype.h>

--- a/examples/echo-x.c
+++ b/examples/echo-x.c
@@ -10,9 +10,6 @@
  * of this file, and for a DISCLAIMER OF ALL WARRANTIES.
  *
  */
-#ifndef lint
-static const char rcsid[] = "$Id: echo-x.c,v 1.1 2001/06/19 15:06:17 robs Exp $";
-#endif /* not lint */
 
 #include "fcgi_config.h"
 

--- a/examples/echo.c
+++ b/examples/echo.c
@@ -10,9 +10,6 @@
  * of this file, and for a DISCLAIMER OF ALL WARRANTIES.
  *
  */
-#ifndef lint
-static const char rcsid[] = "$Id: echo.c,v 1.5 1999/07/28 00:29:37 roberts Exp $";
-#endif /* not lint */
 
 #include "fcgi_config.h"
 

--- a/examples/log-dump.c
+++ b/examples/log-dump.c
@@ -14,9 +14,6 @@
  * of this file, and for a DISCLAIMER OF ALL WARRANTIES.
  *
  */
-#ifndef lint
-static const char rcsid[] = "$Id: log-dump.c,v 1.5 2001/09/01 01:12:26 robs Exp $";
-#endif /* not lint */
 
 #include "fcgi_config.h"
 

--- a/examples/threaded.c
+++ b/examples/threaded.c
@@ -2,10 +2,6 @@
  * threaded.c -- A simple multi-threaded FastCGI application.
  */
 
-#ifndef lint
-static const char rcsid[] = "$Id: threaded.c,v 1.9 2001/11/20 03:23:21 robs Exp $";
-#endif /* not lint */
-
 #include "fcgi_config.h"
 
 #include <pthread.h>

--- a/libfcgi/fcgi_stdio.c
+++ b/libfcgi/fcgi_stdio.c
@@ -11,10 +11,6 @@
  *
  */
 
-#ifndef lint
-static const char rcsid[] = "$Id: fcgi_stdio.c,v 1.15 2009/09/28 00:46:30 robs Exp $";
-#endif /* not lint */
-
 #include <errno.h>  /* for errno */
 #include <stdarg.h> /* for va_arg */
 #include <stdlib.h> /* for malloc */

--- a/libfcgi/fcgiapp.c
+++ b/libfcgi/fcgiapp.c
@@ -10,9 +10,6 @@
  * of this file, and for a DISCLAIMER OF ALL WARRANTIES.
  *
  */
-#ifndef lint
-static const char rcsid[] = "$Id: fcgiapp.c,v 1.35 2003/06/22 00:16:43 robs Exp $";
-#endif /* not lint */
 
 #include <assert.h>
 #include <errno.h>

--- a/libfcgi/os_unix.c
+++ b/libfcgi/os_unix.c
@@ -16,10 +16,6 @@
  *  snapper@openmarket.com
  */
 
-#ifndef lint
-static const char rcsid[] = "$Id: os_unix.c,v 1.40 2009/10/05 23:34:50 robs Exp $";
-#endif /* not lint */
-
 #include "fcgi_config.h"
 
 #include <sys/types.h>

--- a/libfcgi/os_win32.c
+++ b/libfcgi/os_win32.c
@@ -16,9 +16,6 @@
  * (Special thanks to Karen and Bill.  They made my job much easier and
  *  significantly more enjoyable.)
  */
-#ifndef lint
-static const char rcsid[] = "$Id: os_win32.c,v 1.36 2009/09/28 01:09:57 robs Exp $";
-#endif /* not lint */
 
 #define WIN32_LEAN_AND_MEAN 
 #include <windows.h>

--- a/libfcgi/strerror.c
+++ b/libfcgi/strerror.c
@@ -34,11 +34,6 @@
  * SUCH DAMAGE.
  */
 
-#if defined(LIBC_SCCS) && !defined(lint)
-/*static char *sccsid = "from: @(#)strerror.c	5.6 (Berkeley) 5/4/91";*/
-static char *rcsid = "$Id: strerror.c,v 1.2 1999/07/27 14:59:09 roberts Exp $";
-#endif /* LIBC_SCCS and not lint */
-
 #include "fcgi_config.h"
 
 #if ! defined (HAVE_STRERROR)


### PR DESCRIPTION
This fixes compiler warnings:

    warning: ‘rcsid’ defined but not used [-Wunused-const-variable=]

Signed-off-by: Stefan Weil <sw@weilnetz.de>