### PR TITLE
Provide pkg-config files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,10 @@ SUBDIRS = libfcgi cgi-fcgi examples include
 
 include_HEADERS = fcgi_config.h
 
+pkgconfigdir = @pkgconfigdir@
+pkgconfig_DATA = fcgi.pc \
+                 fcgi++.pc
+
 EXTRA_DIST = LICENSE.TERMS              \
              Makefile.nt                \
              cgi-fcgi/cgi-fcgi.mak      \

--- a/configure.in
+++ b/configure.in
@@ -68,10 +68,18 @@ AC_SUBST([SYSTEM])
 
 AC_PROG_CC_WARNINGS
 
+AC_ARG_WITH([pkgconfigdir],
+  [AS_HELP_STRING([--with-pkgconfigdir=DIR], [pkgconfig files])],
+  [pkgconfigdir=$withval],
+  [pkgconfigdir="\${libdir}/pkgconfig"])
+AC_SUBST([pkgconfigdir], [$pkgconfigdir])
+
 AC_CONFIG_FILES([Makefile
                  cgi-fcgi/Makefile
                  include/Makefile
                  libfcgi/Makefile
-                 examples/Makefile])
+                 examples/Makefile
+                 fcgi.pc
+                 fcgi++.pc])
 
 AC_OUTPUT

--- a/fcgi++.pc.in
+++ b/fcgi++.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+
+Name: fcgi
+Description: FastCGI C++ Developer's Kit
+URL: https://fastcgi-archives.github.io
+Version: @VERSION@
+Libs: -L${libdir} -lfcgi++

--- a/fcgi.pc.in
+++ b/fcgi.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+
+Name: fcgi
+Description: FastCGI Developer's Kit
+URL: https://fastcgi-archives.github.io
+Version: @VERSION@
+Libs: -L${libdir} -lfcgi


### PR DESCRIPTION
Motivation for this change: Better integration with Yocto cross toolchain.