### PR TITLE
Link libfcgi against the math library

### DIFF
--- a/libfcgi/Makefile.am
+++ b/libfcgi/Makefile.am
@@ -19,6 +19,7 @@ libfcgi_la_SOURCES = $(INCLUDE_FILES)  \
                      os_@SYSTEM@.c
 libfcgi_la_CC      = @PTHREAD_CC@
 libfcgi_la_CFLAGS  = @PTHREAD_CFLAGS@
+libfcgi_la_LIBADD  = -lm
 libfcgi_la_LDFLAGS = @EXTRA_LIBS@ -no-undefined
 
 libfcgi___la_SOURCES = $(INCLUDE_FILES)       \


### PR DESCRIPTION
Signed-off-by: Thomas Claveirole <thomas.claveirole@green-communications.fr>
[Louis: rebase on top of 2.4.2]
Signed-off-by: Louis Rannou <louis.rannou@smile.fr>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libfcgi/0001-link-against-math.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>