### PR TITLE
add fcgi2 to vcpkg

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -27,14 +27,12 @@ AC_DEFUN([FCGI_COMMON_CHECKS], [
 		   [Define if there's a fileno() prototype in stdio.h])],
 	    AC_MSG_RESULT([no]))
 
-    if test "$HAVE_SYS_SOCKET_H"; then
 	AC_MSG_CHECKING([for socklen_t in sys/socket.h])
 	AC_EGREP_HEADER([socklen_t], [sys/socket.h],
 	    [AC_MSG_RESULT([yes])
 	     AC_DEFINE([HAVE_SOCKLEN], [1],
 			       [Define if the socklen_t typedef is in sys/socket.h])],
 	   AC_MSG_RESULT([no]))
-    fi
 
     #--------------------------------------------------------------------
     #  Do we need cross-process locking on this platform?

--- a/libfcgi/libfcgi.mak
+++ b/libfcgi/libfcgi.mak
@@ -37,20 +37,17 @@ ALL : "$(OUTDIR)\libfcgi.dll"
 
 
 CLEAN :
-	-@erase "$(INTDIR)\fcgi_stdio.obj"
-	-@erase "$(INTDIR)\fcgiapp.obj"
-	-@erase "$(INTDIR)\fcgio.obj"
-	-@erase "$(INTDIR)\os_win32.obj"
-	-@erase "$(INTDIR)\vc60.idb"
-	-@erase "$(OUTDIR)\libfcgi.dll"
-	-@erase "$(OUTDIR)\libfcgi.exp"
-	-@erase "$(OUTDIR)\libfcgi.lib"
+    -@erase "$(INTDIR)\*.obj"
+    -@erase "$(INTDIR)\*.idb"
+    -@erase "$(OUTDIR)\*.dll"
+    -@erase "$(OUTDIR)\*.exp"
+    -@erase "$(OUTDIR)\*.lib"
 
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
 CPP=cl.exe
-CPP_PROJ=/nologo /MD /W3 /O2 /Ob2 /I "..\include" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"$(INTDIR)\libfcgi.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
+CPP_PROJ=/nologo /MD /W3 /O2 /Ob2 /I "..\include" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /D "DLLAPI=__declspec(dllexport)" /Fp"$(INTDIR)\libfcgi.pch" /nologo /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
 
 .c{$(INTDIR)}.obj::
    $(CPP) @<<
@@ -88,14 +85,14 @@ RSC=rc.exe
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\libfcgi.bsc" 
 BSC32_SBRS= \
-	
+    
 LINK32=link.exe
-LINK32_FLAGS=Ws2_32.lib /nologo /dll /pdb:none /machine:I386 /out:"$(OUTDIR)\libfcgi.dll" /implib:"$(OUTDIR)\libfcgi.lib" 
+LINK32_FLAGS=Ws2_32.lib Kernel32.lib Windowsapp.lib /APPCONTAINER /nologo /dll /pdb:none  /out:"$(OUTDIR)\libfcgi.dll" /implib:"$(OUTDIR)\libfcgi.lib" 
 LINK32_OBJS= \
-	"$(INTDIR)\fcgi_stdio.obj" \
-	"$(INTDIR)\fcgiapp.obj" \
-	"$(INTDIR)\fcgio.obj" \
-	"$(INTDIR)\os_win32.obj"
+    "$(INTDIR)\fcgi_stdio.obj" \
+    "$(INTDIR)\fcgiapp.obj" \
+    "$(INTDIR)\fcgio.obj" \
+    "$(INTDIR)\os_win32.obj"
 
 "$(OUTDIR)\libfcgi.dll" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
     $(LINK32) @<<
@@ -114,27 +111,21 @@ ALL : "$(OUTDIR)\libfcgi.dll" "$(OUTDIR)\libfcgi.bsc"
 
 
 CLEAN :
-	-@erase "$(INTDIR)\fcgi_stdio.obj"
-	-@erase "$(INTDIR)\fcgi_stdio.sbr"
-	-@erase "$(INTDIR)\fcgiapp.obj"
-	-@erase "$(INTDIR)\fcgiapp.sbr"
-	-@erase "$(INTDIR)\fcgio.obj"
-	-@erase "$(INTDIR)\fcgio.sbr"
-	-@erase "$(INTDIR)\os_win32.obj"
-	-@erase "$(INTDIR)\os_win32.sbr"
-	-@erase "$(INTDIR)\vc60.idb"
-	-@erase "$(INTDIR)\vc60.pdb"
-	-@erase "$(OUTDIR)\libfcgi.bsc"
-	-@erase "$(OUTDIR)\libfcgi.dll"
-	-@erase "$(OUTDIR)\libfcgi.exp"
-	-@erase "$(OUTDIR)\libfcgi.lib"
-	-@erase "$(OUTDIR)\libfcgi.map"
+    -@erase "$(INTDIR)\*.obj"
+    -@erase "$(INTDIR)\*.sbr"
+    -@erase "$(INTDIR)\*.idb"
+    -@erase "$(INTDIR)\*.pdb"
+    -@erase "$(OUTDIR)\*.bsc"
+    -@erase "$(OUTDIR)\*.dll"
+    -@erase "$(OUTDIR)\*.exp"
+    -@erase "$(OUTDIR)\*.lib"
+    -@erase "$(OUTDIR)\*.map"
 
 "$(OUTDIR)" :
     if not exist "$(OUTDIR)/$(NULL)" mkdir "$(OUTDIR)"
 
 CPP=cl.exe
-CPP_PROJ=/nologo /MDd /W4 /Gm /Gi /ZI /Od /I "..\include" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /FR"$(INTDIR)\\" /Fp"$(INTDIR)\libfcgi.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
+CPP_PROJ=/nologo /MDd /W4 /Gm- /Gi /ZI /Od /I "..\include" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /D "DLLAPI=__declspec(dllexport)" /FR"$(INTDIR)\\" /Fp"$(INTDIR)\libfcgi.pch" /nologo /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\libfcgi.pdb" /FD /GZ /c 
 
 .c{$(INTDIR)}.obj::
    $(CPP) @<<
@@ -172,10 +163,10 @@ RSC=rc.exe
 BSC32=bscmake.exe
 BSC32_FLAGS=/nologo /o"$(OUTDIR)\libfcgi.bsc" 
 BSC32_SBRS= \
-	"$(INTDIR)\fcgi_stdio.sbr" \
-	"$(INTDIR)\fcgiapp.sbr" \
-	"$(INTDIR)\fcgio.sbr" \
-	"$(INTDIR)\os_win32.sbr"
+    "$(INTDIR)\fcgi_stdio.sbr" \
+    "$(INTDIR)\fcgiapp.sbr" \
+    "$(INTDIR)\fcgio.sbr" \
+    "$(INTDIR)\os_win32.sbr"
 
 "$(OUTDIR)\libfcgi.bsc" : "$(OUTDIR)" $(BSC32_SBRS)
     $(BSC32) @<<
@@ -183,12 +174,12 @@ BSC32_SBRS= \
 <<
 
 LINK32=link.exe
-LINK32_FLAGS=Ws2_32.lib /nologo /dll /profile /map:"$(INTDIR)\libfcgi.map" /debug /machine:I386 /out:"$(OUTDIR)\libfcgi.dll" /implib:"$(OUTDIR)\libfcgi.lib" 
+LINK32_FLAGS=Ws2_32.lib Kernel32.lib Windowsapp.lib /APPCONTAINER /nologo /dll /profile /map:"$(INTDIR)\libfcgi.map" /debug  /out:"$(OUTDIR)\libfcgi.dll" /implib:"$(OUTDIR)\libfcgi.lib" 
 LINK32_OBJS= \
-	"$(INTDIR)\fcgi_stdio.obj" \
-	"$(INTDIR)\fcgiapp.obj" \
-	"$(INTDIR)\fcgio.obj" \
-	"$(INTDIR)\os_win32.obj"
+    "$(INTDIR)\fcgi_stdio.obj" \
+    "$(INTDIR)\fcgiapp.obj" \
+    "$(INTDIR)\fcgio.obj" \
+    "$(INTDIR)\os_win32.obj"
 
 "$(OUTDIR)\libfcgi.dll" : "$(OUTDIR)" $(DEF_FILE) $(LINK32_OBJS)
     $(LINK32) @<<
@@ -199,30 +190,30 @@ LINK32_OBJS= \
 
 
 ..\libfcgi\fcgi_stdio.c : \
-	"..\include\fcgi_config.h"\
-	"..\include\fcgi_stdio.h"\
-	"..\include\fcgiapp.h"\
-	"..\include\fcgimisc.h"\
-	"..\include\fcgios.h"\
-	
+    "..\include\fcgi_config.h"\
+    "..\include\fcgi_stdio.h"\
+    "..\include\fcgiapp.h"\
+    "..\include\fcgimisc.h"\
+    "..\include\fcgios.h"\
+    
 
 ..\libfcgi\fcgiapp.c : \
-	"..\include\fastcgi.h"\
-	"..\include\fcgi_config.h"\
-	"..\include\fcgiapp.h"\
-	"..\include\fcgimisc.h"\
-	"..\include\fcgios.h"\
-	
+    "..\include\fastcgi.h"\
+    "..\include\fcgi_config.h"\
+    "..\include\fcgiapp.h"\
+    "..\include\fcgimisc.h"\
+    "..\include\fcgios.h"\
+    
 
 ..\libfcgi\fcgio.cpp : \
-	"..\include\fcgiapp.h"\
-	"..\include\fcgio.h"\
-	
+    "..\include\fcgiapp.h"\
+    "..\include\fcgio.h"\
+    
 
 ..\libfcgi\os_win32.c : \
-	"..\include\fcgi_config.h"\
-	"..\include\fcgimisc.h"\
-	"..\include\fcgios.h"\
+    "..\include\fcgi_config.h"\
+    "..\include\fcgimisc.h"\
+    "..\include\fcgios.h"\
 
 
 !IF "$(CFG)" == "release" || "$(CFG)" == "debug"
@@ -232,14 +223,14 @@ SOURCE=..\libfcgi\fcgi_stdio.c
 
 
 "$(INTDIR)\fcgi_stdio.obj" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "debug"
 
 
-"$(INTDIR)\fcgi_stdio.obj"	"$(INTDIR)\fcgi_stdio.sbr" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+"$(INTDIR)\fcgi_stdio.obj"    "$(INTDIR)\fcgi_stdio.sbr" : $(SOURCE) "$(INTDIR)"
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 
@@ -250,14 +241,14 @@ SOURCE=..\libfcgi\fcgiapp.c
 
 
 "$(INTDIR)\fcgiapp.obj" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "debug"
 
 
-"$(INTDIR)\fcgiapp.obj"	"$(INTDIR)\fcgiapp.sbr" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+"$(INTDIR)\fcgiapp.obj"    "$(INTDIR)\fcgiapp.sbr" : $(SOURCE) "$(INTDIR)"
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 
@@ -266,20 +257,20 @@ SOURCE=..\libfcgi\fcgio.cpp
 
 !IF  "$(CFG)" == "release"
 
-CPP_SWITCHES=/nologo /MD /W3 /GX /O2 /Ob2 /I "..\include" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /Fp"$(INTDIR)\libfcgi.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
+CPP_SWITCHES=/nologo /MD /W3 /EHsc /O2 /Ob2 /I "..\include" /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /D "DLLAPI=__declspec(dllexport)" /Fp"$(INTDIR)\libfcgi.pch" /nologo /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /c 
 
 "$(INTDIR)\fcgio.obj" : $(SOURCE) "$(INTDIR)"
-	$(CPP) @<<
+    $(CPP) @<<
   $(CPP_SWITCHES) $(SOURCE)
 <<
 
 
 !ELSEIF  "$(CFG)" == "debug"
 
-CPP_SWITCHES=/nologo /MDd /W3 /Gm /Gi /GX /ZI /Od /I "..\include" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /FR"$(INTDIR)\\" /Fp"$(INTDIR)\libfcgi.pch" /YX /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
+CPP_SWITCHES=/nologo /MDd /W3 /Gm- /Gi /EHsc /ZI /Od /I "..\include" /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /D "DLLAPI=__declspec(dllexport)" /FR"$(INTDIR)\\" /Fp"$(INTDIR)\libfcgi.pch" /nologo /Fo"$(INTDIR)\\" /Fd"$(INTDIR)\\" /FD /GZ /c 
 
-"$(INTDIR)\fcgio.obj"	"$(INTDIR)\fcgio.sbr" : $(SOURCE) "$(INTDIR)"
-	$(CPP) @<<
+"$(INTDIR)\fcgio.obj"    "$(INTDIR)\fcgio.sbr" : $(SOURCE) "$(INTDIR)"
+    $(CPP) @<<
   $(CPP_SWITCHES) $(SOURCE)
 <<
 
@@ -293,14 +284,14 @@ SOURCE=..\libfcgi\os_win32.c
 
 
 "$(INTDIR)\os_win32.obj" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ELSEIF  "$(CFG)" == "debug"
 
 
-"$(INTDIR)\os_win32.obj"	"$(INTDIR)\os_win32.sbr" : $(SOURCE) "$(INTDIR)"
-	$(CPP) $(CPP_PROJ) $(SOURCE)
+"$(INTDIR)\os_win32.obj"    "$(INTDIR)\os_win32.sbr" : $(SOURCE) "$(INTDIR)"
+    $(CPP) $(CPP_PROJ) $(SOURCE)
 
 
 !ENDIF 


### PR DESCRIPTION
In order to add fcgi2 to vcpkg, I modified the libfcgi.mak file to support compilation under x64 and uwp, and modified acinclude.m4 so that it does not report an error under linux