### PR TITLE
pkg-config: added includedir assignment

### DIFF
--- a/fcgi++.pc.in
+++ b/fcgi++.pc.in
@@ -1,9 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
+includedir=${exec_prefix}/include
 
 Name: fcgi
 Description: FastCGI C++ Developer's Kit
 URL: https://fastcgi-archives.github.io
 Version: @VERSION@
 Libs: -L${libdir} -lfcgi++
+Cflags: -I${includedir}

--- a/fcgi.pc.in
+++ b/fcgi.pc.in
@@ -1,9 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
+includedir=${exec_prefix}/include
 
 Name: fcgi
 Description: FastCGI Developer's Kit
 URL: https://fastcgi-archives.github.io
 Version: @VERSION@
 Libs: -L${libdir} -lfcgi
+Cflags: -I${includedir}


### PR DESCRIPTION
When the library is installed in non-standard location compiler can't find
fcgiapp.h header file. Populating includedir and cflags fixes that

Signed-off-by: Vyacheslav Yurkov <Vyacheslav.Yurkov@bruker.com>