### PR TITLE
Stop leaking information across requests

### DIFF
--- a/perl/FCGI.PL
+++ b/perl/FCGI.PL
@@ -291,14 +291,14 @@ sub Request(;***$*$) {
 
 sub accept() {
     warn "accept called as a method; you probably wanted to call Accept" if @_;
-    if (defined %FCGI::ENV) {
-	%ENV = %FCGI::ENV;
+    if ( defined($FCGI::ENV) ) {
+        %ENV = %$FCGI::ENV;
     } else {
-	%FCGI::ENV = %ENV;
+        $FCGI::ENV = {%ENV};
     }
     my $rc = Accept($global_request);
-    for (keys %FCGI::ENV) {
-	$ENV{$_} = $FCGI::ENV{$_} unless exists $ENV{$_};
+    for (keys %$FCGI::ENV) {
+        $ENV{$_} = $FCGI::ENV->{$_} unless exists $ENV{$_};
     }
 
     # not SFIO
@@ -310,7 +310,7 @@ sub accept() {
 
 sub finish() {
     warn "finish called as a method; you probably wanted to call Finish" if @_;
-    %ENV = %FCGI::ENV if (defined %FCGI::ENV);
+    %ENV = %$FCGI::ENV if defined($FCGI::ENV);
 
     # not SFIO
     if (tied (*STDIN)) {


### PR DESCRIPTION
%hash is false if the hash hasn't been assigned to, *or* if the hash is simply
empty. This causes the environment from the *second* request (that is, the
environment produced by the first request) to be saved as default if the first
request had empty environment. This way, request after the first can get access
to credentials set up by the first request.

Instead of fixing this, I'd much rather remove this old and buggy
interface. However, 10 years of deprecation don't seem to have been enough for
CGI::Fast to switch to the new and properly supported interface. :-(

This is CVE-2011-2766.