### PR TITLE
Remove empty m4 directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ fcgi++.pc
 install-sh
 missing
 ltmain.sh
+m4/

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Looking at some of the differences between this and https://github.com/perl-catalyst/FCGI.

The m4 is automatically created by autogen.sh