### PR TITLE
Remove AC_CONFIG_MACRO_DIR for non-existent `m4` directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,6 @@ dnl     to configure the system for the local environment.
 
 AC_INIT([fcgi], [2.4.7])
 AM_INIT_AUTOMAKE([1.11 foreign])
-AC_CONFIG_MACRO_DIR([m4])
 AM_CONFIG_HEADER(fcgi_config.h)
 
 LT_INIT([win32-dll])


### PR DESCRIPTION
With the `m4` directory removed (#76), the `AC_CONFIG_MACRO_DIR` results in an error.

```
     8     autoreconf: export WARNINGS=
     9     autoreconf: Entering directory '.'
     10    autoreconf: configure.ac: not using Gettext
     11    autoreconf: running: aclocal -I /home/software/spack/__spack_path_pl
           aceholder__/__spack_path_placeholder__/__spack_path_placeholder__/__
           spack_path_placeholder__/__spack_path_placeholder__/__spack_path_pla
           ceholder__/__spack_path_placeholder__/__spack_path_placeholder__/__s
           pack_path_placeh/linux-x86_64_v3/libtool-2.4.7-pkrzmj3exucbqdwkqidyc
           6czgjmbz4hs/share/aclocal -I /usr/share/aclocal --force -I m4
  >> 12    aclocal: error: couldn't open directory 'm4': No such file or direct
           ory
  >> 13    autoreconf: error: aclocal failed with exit status: 1
```

Ref: https://gitlab.spack.io/spack/spack-packages/-/jobs/19061060